### PR TITLE
set use native driver mandatory prop to false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,17 +60,20 @@ export default class Component extends React.PureComponent {
 
       Animated.timing(this.loadingValue.width, {
         toValue: widthEnd,
-        duration: 400
+        duration: 400,
+        useNativeDriver: false,
       }).start();
 
       Animated.timing(this.loadingValue.borderRadius, {
         toValue: borderRadiusEnd,
-        duration: 400
+        duration: 400,
+        useNativeDriver: false,
       }).start();
 
       Animated.timing(this.loadingValue.opacity, {
         toValue: opacityEnd,
-        duration: 300
+        duration: 300,
+        useNativeDriver: false,
       }).start();
     }
   }


### PR DESCRIPTION
React native animated now has a mandatory property `useNativeDriver` and it was accusing error, so I set it correctly